### PR TITLE
Bump NUnit.Analyzers from 4.9.2 to 4.10.0

### DIFF
--- a/NUnitTests/NUnitTests.csproj
+++ b/NUnitTests/NUnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: NUnit.Analyzers dependency-version: 4.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...